### PR TITLE
feat(dataset): Implement dataset support

### DIFF
--- a/pystoned/__init__.py
+++ b/pystoned/__init__.py
@@ -8,6 +8,7 @@ from . import CNLSG2
 from . import CNLSZ
 from . import CQER
 from . import CQRDDF
+from . import dataset
 from . import DEA
 from . import DEA2CNLS
 from . import directV
@@ -29,6 +30,7 @@ __all__ = [
     'CNLSZ',
     'CQER',
     'CQRDDF',
+    'dataset',
     'DEA',
     'DEA2CNLS',
     'directV',

--- a/pystoned/dataset.py
+++ b/pystoned/dataset.py
@@ -1,0 +1,17 @@
+import pandas as pd
+import numpy as np
+
+def firm(inputlist=['OPEX', 'CAPEX'], output='Energy'):
+    url = 'https://raw.githubusercontent.com/ds2010/pyStoNED-Tutorials/master/Data/firms.csv'
+    data = pd.read_csv(url, error_bad_lines=False)
+
+    # output 
+    y = data[output]
+
+    # input 
+    x = []
+    for item in inputlist:
+        x.append(np.asmatrix(data[item]).T)
+    x = np.concatenate((x), axis=1)
+
+    return x, y


### PR DESCRIPTION
Hi, I recently considered about the example we used for testing pystoned could be a feature.

This is inspired by [sklearn](https://github.com/scikit-learn/scikit-learn), which provides user [toy datasets](https://scikit-learn.org/stable/datasets/index.html#toy-datasets) for better comprehension of the usage/feature of the model.
The toy datasets made sklearn the wildly used all over the world, since it is pretty easy to use/comprehend for the beginners.

This pr reduce the complexity of the use of the datasets 
Original:
```python
import pandas as pd
import numpy as np

url = 'https://raw.githubusercontent.com/ds2010/pyStoNED-Tutorials/master/Data/firms.csv'
df = pd.read_csv(url, error_bad_lines=False)
df.head(5)

# output
y = df['Energy']

# inputs
x1 = df['OPEX']
x1 = np.asmatrix(x1).T
x2 = df['CAPEX']
x2 = np.asmatrix(x2).T
x = np.concatenate((x1, x2), axis=1)
```
This pr:
```python
from pystoned import dataset

x, y = dataset.firm(['OPEX', 'CAPEX'], 'Energy')
```

> This pr is not yet finished

Please give me the information of the datasets, in order to:
* making sure the datasets are used in rational way
* give the user the brief introduction of the dataset
* etc..

thanks for your review, do not merge yet!